### PR TITLE
Quitado console.log

### DIFF
--- a/components/coffee/index.js
+++ b/components/coffee/index.js
@@ -61,7 +61,6 @@ const Coffee = ({ setShare, coffee, loadNewCoffees, password, isAdmin }) => {
                     icon={faShareAlt}
                     className={style.shareIcon}
                     onClick={() => {
-                        console.log(coffee);
                         setShare(coffee);
                     }}
                     width="20"


### PR DESCRIPTION
Se mostraba al hacer clic en el Compartir del Café